### PR TITLE
Create github action for publish gh pages on merge

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy Doc Site to GH Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - name: Install Yarn
+        run: npm install -g yarn
+      - name: Install Dependencies 
+        working-directory: doc-site
+        run: yarn install
+      - name: Deploy with gh-pages
+        working-directory: doc-site
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          npm run deploy -- -u "github-actions-bot <support+actions@github.com>"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/doc-site/README.md
+++ b/doc-site/README.md
@@ -9,7 +9,4 @@ yarn run dev
 ``` 
 
 Deploy:
-This will deploy to production hosting so do not run unless you are sure you want to publish your changes.
-```bash
-yarn deploy
-```
+Deployments are handled automatically through github actions 


### PR DESCRIPTION
Deploy Pages through Github Actions rather than depending on a manual process 