### PR TITLE
Fix Core Exchange docs link broken by markdown bold

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the OpenAPI specification files for Plaid's Core Exchan
 
 Core Exchange is Plaid's implementation based on the Financial Data Exchange (FDX) API specification. It provides a secure, standardized way to access financial data while maintaining compliance with industry standards.
 
-To learn more about Core Exchange, including detailed documentation, integration guides, and API references, visit: **https://plaid.com/core-exchange/docs/**
+To learn more about Core Exchange, including detailed documentation, integration guides, and API references, visit <https://plaid.com/core-exchange/docs/>.
 
 ## Repository Structure
 


### PR DESCRIPTION
The README pointed at \`https://plaid.com/core-exchange/docs/**\` (404). The trailing \`**\` came from the markdown bold wrappers being glued onto the auto-linked URL. Switched to angle-bracket autolink syntax (\`<https://plaid.com/core-exchange/docs/>\`) so the URL is clickable and the bold no longer leaks into it.

## Test plan
- [ ] On the rendered README, confirm the docs link target is \`https://plaid.com/core-exchange/docs/\` (no trailing \`**\`) and loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 80ee54fa-3880-4c3c-b81d-9bf74c3adb2c