### PR TITLE
Update README for Core Exchange v6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ versions/
     corex.yaml
   6.3/
     corex.yaml
+  6.4/
+    corex.yaml
 ```
 
 Each version directory contains:
@@ -46,7 +48,7 @@ The OpenAPI specifications in this repository define the complete Core Exchange 
 
 ## Version Information
 
-- **Latest Version**: 6.3
+- **Latest Version**: 6.4
 - **Specification Format**: OpenAPI 3.0.3
 - **Based on**: FDX (Financial Data Exchange) API specification
 


### PR DESCRIPTION
Adds 6.4 to the versions tree in the README and bumps the **Latest Version** line to 6.4.

The 6.4 spec file was already published to `main` via the corex-internal spec sync (#9), which did not touch the README — this PR fills that gap so the version index reflects 6.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)