### PR TITLE
Sync Core Exchange investment spec updates

### DIFF
--- a/versions/4.6/corex.yaml
+++ b/versions/4.6/corex.yaml
@@ -1789,14 +1789,13 @@ components:
                   securityIdType: CUSIP
                   holdingName: 'Apple Inc.'
                   holdingType: STOCK
-                  holdingSubType: CASH
                   symbol: AAPL
                   purchasedPrice: 150.00
                   currentUnitPrice: 175.00
                   currentUnitPriceDate: '2023-10-01T14:46:41.000Z'
                   units: 1
                   marketValue: 1750.00
-                  cashAccount: true
+                  cashAccount: false
                   currency:
                     currencyCode: USD
                   fiAttributes:
@@ -1903,9 +1902,8 @@ components:
               type: array
               description: |
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -1922,7 +1920,7 @@ components:
     HoldingType:
       title: Holding Type
       description: |
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2577,7 +2575,7 @@ components:
             fiAttributes:
               type: array
               description: |
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:

--- a/versions/5.0/corex.yaml
+++ b/versions/5.0/corex.yaml
@@ -1610,7 +1610,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             lastPaymentAmount:
@@ -1709,7 +1709,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             principalBalance:
@@ -1815,14 +1815,13 @@ components:
                   securityIdType: CUSIP
                   holdingName: 'Apple Inc.'
                   holdingType: STOCK
-                  holdingSubType: CASH
                   symbol: AAPL
                   purchasedPrice: 150.00
                   currentUnitPrice: 175.00
                   currentUnitPriceDate: '2023-10-01'
                   units: 1
                   marketValue: 1750.00
-                  cashAccount: true
+                  cashAccount: false
                   currency:
                     currencyCode: USD
                   fiAttributes:
@@ -1929,9 +1928,8 @@ components:
               type: array
               description: |
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -1948,7 +1946,7 @@ components:
     HoldingType:
       title: Holding Type
       description: |
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2604,7 +2602,7 @@ components:
             fiAttributes:
               type: array
               description: |
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:

--- a/versions/5.1/corex.yaml
+++ b/versions/5.1/corex.yaml
@@ -1615,7 +1615,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             lastPaymentAmount:
@@ -1714,7 +1714,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             principalBalance:
@@ -1820,14 +1820,13 @@ components:
                   securityIdType: CUSIP
                   holdingName: 'Apple Inc.'
                   holdingType: STOCK
-                  holdingSubType: CASH
                   symbol: AAPL
                   purchasedPrice: 150.00
                   currentUnitPrice: 175.00
                   currentUnitPriceDate: '2023-10-01'
                   units: 1
                   marketValue: 1750.00
-                  cashAccount: true
+                  cashAccount: false
                   currency:
                     currencyCode: USD
                   fiAttributes:
@@ -1934,9 +1933,8 @@ components:
               type: array
               description: |
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -1953,7 +1951,7 @@ components:
     HoldingType:
       title: Holding Type
       description: |
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2611,7 +2609,7 @@ components:
             fiAttributes:
               type: array
               description: |
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:

--- a/versions/5.2/corex.yaml
+++ b/versions/5.2/corex.yaml
@@ -1725,7 +1725,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             lastPaymentAmount:
@@ -1824,7 +1824,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             principalBalance:
@@ -1930,14 +1930,13 @@ components:
                   securityIdType: CUSIP
                   holdingName: 'Apple Inc.'
                   holdingType: STOCK
-                  holdingSubType: CASH
                   symbol: AAPL
                   purchasedPrice: 150.00
                   currentUnitPrice: 175.00
                   currentUnitPriceDate: '2023-10-01'
                   units: 1
                   marketValue: 1750.00
-                  cashAccount: true
+                  cashAccount: false
                   currency:
                     currencyCode: USD
                   fiAttributes:
@@ -2044,9 +2043,8 @@ components:
               type: array
               description: |
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -2063,7 +2061,7 @@ components:
     HoldingType:
       title: Holding Type
       description: |
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2747,7 +2745,7 @@ components:
             fiAttributes:
               type: array
               description: |
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:

--- a/versions/5.3/corex.yaml
+++ b/versions/5.3/corex.yaml
@@ -1766,7 +1766,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             lastPaymentAmount:
@@ -1865,7 +1865,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             principalBalance:
@@ -1971,14 +1971,13 @@ components:
                   securityIdType: CUSIP
                   holdingName: 'Apple Inc.'
                   holdingType: STOCK
-                  holdingSubType: CASH
                   symbol: AAPL
                   purchasedPrice: 150.00
                   currentUnitPrice: 175.00
                   currentUnitPriceDate: '2023-10-01'
                   units: 1
                   marketValue: 1750.00
-                  cashAccount: true
+                  cashAccount: false
                   currency:
                     currencyCode: USD
                   fiAttributes:
@@ -2085,9 +2084,8 @@ components:
               type: array
               description: |
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -2104,7 +2102,7 @@ components:
     HoldingType:
       title: Holding Type
       description: |
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2788,7 +2786,7 @@ components:
             fiAttributes:
               type: array
               description: |
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:

--- a/versions/6.0/corex.yaml
+++ b/versions/6.0/corex.yaml
@@ -1698,7 +1698,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             lastPaymentAmount:
@@ -1783,7 +1783,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             principalBalance:
@@ -1883,14 +1883,13 @@ components:
                     idType: CUSIP
                   holdingName: 'Apple Inc.'
                   holdingType: STOCK
-                  holdingSubType: CASH
                   symbol: AAPL
                   purchasedPrice: 150.00
                   currentUnitPrice: 175.00
                   currentUnitPriceDate: '2023-10-01'
                   units: 1
                   marketValue: 1750.00
-                  cashAccount: true
+                  cashAccount: false
                   currency:
                     currencyCode: USD
                   fiAttributes:
@@ -1992,9 +1991,8 @@ components:
               type: array
               description: |
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -2022,7 +2020,7 @@ components:
     HoldingType:
       title: Holding Type
       description: |
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2466,7 +2464,7 @@ components:
         * US&#95;CHIPS: Clearinghouse Interbank Payments System (primarily big banks)
         * US&#95;FEDNOW: Federal Reserve Instant Payment System
         
-        **NOTE**: `US&#95;FEDWIRE` and `US&#95;RTP` are not supported payment network types.
+        **NOTE**: `US&#95;FEDNOW` is supported as of v6.0. `US&#95;FEDWIRE` and `US&#95;RTP` are not supported payment network types.
       type: string
       enum:
         - CA_ACSS
@@ -2708,7 +2706,7 @@ components:
             fiAttributes:
               type: array
               description: |
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:
@@ -2725,6 +2723,9 @@ components:
         amount: 428.08
         fees: 4.28
         transactionType: PURCHASED
+        fiAttributes:
+          - name: 'isCashEquivalent'
+            value: 'false'
 
     InvestmentTransactionType:
       title: Investment Transaction Type

--- a/versions/6.1/corex.yaml
+++ b/versions/6.1/corex.yaml
@@ -1698,7 +1698,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: >
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             lastPaymentAmount:
@@ -1783,7 +1783,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: >
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             principalBalance:
@@ -1883,14 +1883,13 @@ components:
                     idType: CUSIP
                   holdingName: 'Apple Inc.'
                   holdingType: STOCK
-                  holdingSubType: CASH
                   symbol: AAPL
                   purchasedPrice: 150.00
                   currentUnitPrice: 175.00
                   currentUnitPriceDate: '2023-10-01'
                   units: 1
                   marketValue: 1750.00
-                  cashAccount: true
+                  cashAccount: false
                   currency:
                     currencyCode: USD
                   fiAttributes:
@@ -1992,9 +1991,8 @@ components:
               type: array
               description: >
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -2022,7 +2020,7 @@ components:
     HoldingType:
       title: Holding Type
       description: >
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2466,7 +2464,7 @@ components:
         * US&#95;CHIPS: Clearinghouse Interbank Payments System (primarily big banks)
         * US&#95;FEDNOW: Federal Reserve Instant Payment System
         
-        **NOTE**: `US&#95;FEDWIRE` and `US&#95;RTP` are not supported payment network types.
+        **NOTE**: `US&#95;FEDNOW` is supported as of v6.0. `US&#95;FEDWIRE` and `US&#95;RTP` are not supported payment network types.
       type: string
       enum:
         - CA_ACSS
@@ -2708,7 +2706,7 @@ components:
             fiAttributes:
               type: array
               description: >
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:
@@ -2725,6 +2723,9 @@ components:
         amount: 428.08
         fees: 4.28
         transactionType: PURCHASED
+        fiAttributes:
+          - name: 'isCashEquivalent'
+            value: 'false'
 
     InvestmentTransactionType:
       title: Investment Transaction Type

--- a/versions/6.2/corex.yaml
+++ b/versions/6.2/corex.yaml
@@ -1714,7 +1714,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             lastPaymentAmount:
@@ -1799,7 +1799,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             principalBalance:
@@ -1899,14 +1899,13 @@ components:
                     idType: CUSIP
                   holdingName: 'Apple Inc.'
                   holdingType: STOCK
-                  holdingSubType: CASH
                   symbol: AAPL
                   purchasedPrice: 150.00
                   currentUnitPrice: 175.00
                   currentUnitPriceDate: '2023-10-01'
                   units: 1
                   marketValue: 1750.00
-                  cashAccount: true
+                  cashAccount: false
                   currency:
                     currencyCode: USD
                   fiAttributes:
@@ -2008,9 +2007,8 @@ components:
               type: array
               description: |
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -2038,7 +2036,7 @@ components:
     HoldingType:
       title: Holding Type
       description: |
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2482,7 +2480,7 @@ components:
         * US&#95;CHIPS: Clearinghouse Interbank Payments System (primarily big banks)
         * US&#95;FEDNOW: Federal Reserve Instant Payment System
         
-        **NOTE**: `US&#95;FEDWIRE` and `US&#95;RTP` are not supported payment network types.
+        **NOTE**: `US&#95;FEDNOW` is supported as of v6.0. `US&#95;FEDWIRE` and `US&#95;RTP` are not supported payment network types.
       type: string
       enum:
         - CA_ACSS
@@ -2724,7 +2722,7 @@ components:
             fiAttributes:
               type: array
               description: |
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:
@@ -2741,6 +2739,9 @@ components:
         amount: 428.08
         fees: 4.28
         transactionType: PURCHASED
+        fiAttributes:
+          - name: 'isCashEquivalent'
+            value: 'false'
 
     InvestmentTransactionType:
       title: Investment Transaction Type

--- a/versions/6.3/corex.yaml
+++ b/versions/6.3/corex.yaml
@@ -1791,7 +1791,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             lastPaymentAmount:
@@ -1886,7 +1886,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             principalBalance:
@@ -1904,7 +1904,7 @@ components:
               example: 190.32
               description: |
                 Minimum payment amount from last statement balance,
-                which is due at `statementAmountDueDate`
+                which is due at the payment due date listed on that statement
             lastPaymentAmount:
               type: number
               example: 2852.91
@@ -1987,14 +1987,13 @@ components:
                     idType: CUSIP
                   holdingName: 'Apple Inc.'
                   holdingType: STOCK
-                  holdingSubType: CASH
                   symbol: AAPL
                   purchasedPrice: 150.00
                   currentUnitPrice: 175.00
                   currentUnitPriceDate: '2023-10-01'
                   units: 1
                   marketValue: 1750.00
-                  cashAccount: true
+                  cashAccount: false
                   currency:
                     currencyCode: USD
                   fiAttributes:
@@ -2096,9 +2095,8 @@ components:
               type: array
               description: |
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -2126,7 +2124,7 @@ components:
     HoldingType:
       title: Holding Type
       description: |
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2496,7 +2494,7 @@ components:
           description: |
             Purpose of the phone number: HOME, BUSINESS, PERSONAL, FAX, or BOTH.
             BOTH indicates number is used for both HOME and BUSINESS purposes.
-            `CELL` value is deprecated in v6.3, replaced as a `network` value
+            `CELL` value is deprecated in v6.3, replaced by the `CELLULAR` value in the `telephoneNetwork` field
         country:
           type: string
           minLength: 1
@@ -2530,7 +2528,7 @@ components:
       description: |
         Purpose of the phone number: HOME, BUSINESS, PERSONAL, FAX, or BOTH.
         BOTH indicates number is used for both HOME and BUSINESS purposes.
-        `CELL` value is deprecated in v6.3, replaced as a `network` value
+        `CELL` value is deprecated in v6.3, replaced by the `CELLULAR` value in the `telephoneNetwork` field
       type: string
       enum:
         - BOTH
@@ -2633,7 +2631,7 @@ components:
         * US&#95;CHIPS: Clearinghouse Interbank Payments System (primarily big banks)
         * US&#95;FEDNOW: Federal Reserve Instant Payment System
         
-        **NOTE**: `US&#95;FEDWIRE` and `US&#95;RTP` are not supported payment network types.
+        **NOTE**: `US&#95;FEDNOW` is supported as of v6.0. `US&#95;FEDWIRE` and `US&#95;RTP` are not supported payment network types.
       type: string
       enum:
         - CA_ACSS
@@ -2885,7 +2883,7 @@ components:
             fiAttributes:
               type: array
               description: |
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:
@@ -2902,6 +2900,9 @@ components:
         amount: 428.08
         fees: 4.28
         transactionType: PURCHASED
+        fiAttributes:
+          - name: 'isCashEquivalent'
+            value: 'false'
 
     InvestmentTransactionType:
       title: Investment Transaction Type

--- a/versions/6.4/corex.yaml
+++ b/versions/6.4/corex.yaml
@@ -1825,7 +1825,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             lastPaymentAmount:
@@ -1927,7 +1927,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             principalBalance:
@@ -1945,7 +1945,7 @@ components:
               example: 190.32
               description: |
                 Minimum payment amount from last statement balance,
-                which is due at `statementAmountDueDate`
+                which is due at the payment due date listed on that statement
             lastPaymentAmount:
               type: number
               example: 2852.91
@@ -2080,14 +2080,13 @@ components:
                     idType: CUSIP
                   holdingName: 'Apple Inc.'
                   holdingType: STOCK
-                  holdingSubType: CASH
                   symbol: AAPL
                   purchasedPrice: 150.00
                   currentUnitPrice: 175.00
                   currentUnitPriceDate: '2023-10-01'
                   units: 1
                   marketValue: 1750.00
-                  cashAccount: true
+                  cashAccount: false
                   currency:
                     currencyCode: USD
                   fiAttributes:
@@ -2344,9 +2343,8 @@ components:
               type: array
               description: |
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -2374,7 +2372,7 @@ components:
     HoldingType:
       title: Holding Type
       description: |
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2744,7 +2742,7 @@ components:
           description: |
             Purpose of the phone number: HOME, BUSINESS, PERSONAL, FAX, or BOTH.
             BOTH indicates number is used for both HOME and BUSINESS purposes.
-            `CELL` value is deprecated in v6.3, replaced as a `network` value
+            `CELL` value is deprecated in v6.3, replaced by the `CELLULAR` value in the `telephoneNetwork` field
         country:
           type: string
           minLength: 1
@@ -2778,7 +2776,7 @@ components:
       description: |
         Purpose of the phone number: HOME, BUSINESS, PERSONAL, FAX, or BOTH.
         BOTH indicates number is used for both HOME and BUSINESS purposes.
-        `CELL` value is deprecated in v6.3, replaced as a `network` value
+        `CELL` value is deprecated in v6.3, replaced by the `CELLULAR` value in the `telephoneNetwork` field
       type: string
       enum:
         - BOTH
@@ -2881,7 +2879,7 @@ components:
         * US&#95;CHIPS: Clearinghouse Interbank Payments System (primarily big banks)
         * US&#95;FEDNOW: Federal Reserve Instant Payment System
         
-        **NOTE**: `US&#95;FEDWIRE` and `US&#95;RTP` are not supported payment network types.
+        **NOTE**: `US&#95;FEDNOW` is supported as of v6.0. `US&#95;FEDWIRE` and `US&#95;RTP` are not supported payment network types.
       type: string
       enum:
         - CA_ACSS
@@ -3133,7 +3131,7 @@ components:
             fiAttributes:
               type: array
               description: |
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:
@@ -3150,6 +3148,9 @@ components:
         amount: 428.08
         fees: 4.28
         transactionType: PURCHASED
+        fiAttributes:
+          - name: 'isCashEquivalent'
+            value: 'false'
 
     InvestmentTransactionType:
       title: Investment Transaction Type

--- a/versions/robinhood-5.1/corex.yaml
+++ b/versions/robinhood-5.1/corex.yaml
@@ -1669,7 +1669,7 @@ components:
               $ref: '#/components/schemas/DateString'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             lastPaymentAmount:
@@ -1768,7 +1768,7 @@ components:
               $ref: '#/components/schemas/DateOrTimestamp'
               description: |
                 Due date of next payment.
-                May differ from `statementAmountDueDate` if the customer pays out of cycle
+                May differ from the payment due date listed on the customer's most recent statement if the customer pays out of cycle
                 ISO 8601 full-date in format 'YYYY-MM-DD' according
                 to [IETF RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6)
             principalBalance:
@@ -1999,9 +1999,8 @@ components:
               type: array
               description: |
                 Array of financial institution-specific attributes.
-                Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-                property in this array.
-                Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+                This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
                 If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
               items:
                 $ref: '#/components/schemas/FiAttribute'
@@ -2035,7 +2034,7 @@ components:
     HoldingType:
       title: Holding Type
       description: |
-        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-type).
+        Plaid maps the holding type to the Plaid [security type](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-type).
         Plaid expects you to return `OTHER` and set the `holdingSubType` to indicate cash-type holdings (`CASH`, `MONEYMARKET`).
       type: string
       enum:
@@ -2111,9 +2110,8 @@ components:
           type: array
           description: |
             Array of financial institution-specific attributes.
-            Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent)
-            property in this array.
-            Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+            Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`.
+            This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-holdings-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
             If you return a value for `isCashEquivalent`, then return the same value for `cashAccount` as a boolean.
           items:
             $ref: '#/components/schemas/FiAttribute'
@@ -2776,7 +2774,7 @@ components:
             fiAttributes:
               type: array
               description: |
-                Array of financial institution-specific attributes. Plaid recommends including a value for [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) property in this array. Plaid accepts `isCashEquivalent` as the attribute name and a string value of `true` or `false`.
+                Array of financial institution-specific attributes. Plaid recommends including a value for the `isCashEquivalent` attribute in this array, sent as a string value of `true` or `false`. This populates the [`is_cash_equivalent`](https://plaid.com/docs/api/products/investments/#investments-transactions-get-response-securities-is-cash-equivalent) field in Plaid's customer-facing API.
               items:
                 $ref: '#/components/schemas/FiAttribute'
           required:


### PR DESCRIPTION
The public specs are missing the latest Core Exchange investment example and copy corrections.

This syncs the compiled OpenAPI specs for supported public versions.